### PR TITLE
Fix: Remove external scrollbar from expenses tab

### DIFF
--- a/client/src/components/ExpenseList.tsx
+++ b/client/src/components/ExpenseList.tsx
@@ -361,7 +361,7 @@ const ExpenseList: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <div className="max-w-full mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="max-w-full mx-auto px-4 sm:px-6 lg:px-8">
         {/* Fixed Header */}
         <div className="fixed top-16 left-0 right-0 z-30 bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
           <div className="max-w-full mx-auto px-4 sm:px-6 lg:px-8 py-6">


### PR DESCRIPTION
Removes the `py-8` class from the main content container in the `ExpenseList` component.

This vertical padding, combined with the `min-h-screen` on the parent, was causing the content to exceed the viewport height, resulting in an unnecessary external scrollbar from the browser.

By removing the padding, the component's height fits within the screen, eliminating the external scrollbar and relying solely on the internal scrollbar for the expenses table as intended.