### PR TITLE
Fix: Remove external scrollbar from expenses tab

### DIFF
--- a/client/src/components/ExpenseList.tsx
+++ b/client/src/components/ExpenseList.tsx
@@ -360,8 +360,8 @@ const ExpenseList: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <div className="max-w-full mx-auto px-4 sm:px-6 lg:px-8">
+    <div className="h-screen overflow-hidden bg-gray-50 dark:bg-gray-900">
+      <div className="max-w-full mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Fixed Header */}
         <div className="fixed top-16 left-0 right-0 z-30 bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
           <div className="max-w-full mx-auto px-4 sm:px-6 lg:px-8 py-6">


### PR DESCRIPTION
Replaces `min-h-screen` with `h-screen` and adds `overflow-hidden` to the main container of the `ExpenseList` component.

This change forces the container to be exactly the height of the viewport and hides any overflow, which definitively prevents the browser's external scrollbar from appearing. This is a more robust solution than the previous attempt, which only removed padding.