### PR TITLE
Fix: Remove external browser scrollbar by correcting the main layout

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -161,9 +161,9 @@ const AppContent: React.FC = () => {
 
   return (
     <ErrorBoundary>
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="h-screen overflow-hidden bg-gray-50 dark:bg-gray-900">
         <Navigation activeTab={activeTab} onTabChange={setActiveTab} />
-        <main>{renderContent()}</main>
+        <main className="h-full overflow-y-auto">{renderContent()}</main>
 
         {/* FAB to open AI Chat */}
         <button

--- a/client/src/components/ExpenseList.tsx
+++ b/client/src/components/ExpenseList.tsx
@@ -360,7 +360,7 @@ const ExpenseList: React.FC = () => {
   };
 
   return (
-    <div className="h-screen overflow-hidden bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       <div className="max-w-full mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Fixed Header */}
         <div className="fixed top-16 left-0 right-0 z-30 bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">


### PR DESCRIPTION
This commit addresses a persistent issue where an external browser scrollbar would appear on various tabs, including the expenses tab. Previous attempts to fix this by targeting individual components were unsuccessful because the root cause was in the main application layout.

The fix is applied to `client/src/App.tsx`:
1.  The main container `div` is changed from `min-h-screen` to `h-screen` and `overflow-hidden` is added. This forces the container to be exactly the height of the viewport and prevents any content from causing the browser itself to scroll.
2.  The `<main>` element, which wraps the content of each tab, is given the classes `h-full` and `overflow-y-auto`. This ensures that if the content of a specific tab (like the expenses list) is taller than the available space, an internal scrollbar will appear within the main content area, rather than on the browser window.

This change provides a global and robust solution, ensuring a consistent and clean UI across the entire application.